### PR TITLE
set a restart for the can device

### DIFF
--- a/03-install-n2k/files/can0
+++ b/03-install-n2k/files/can0
@@ -1,7 +1,8 @@
 #physical can interfaces
-allow-hotplug can0
+auto can0
 iface can0 can static
 bitrate 250000
+pre-up ip link set can0 type can restart-ms 100
 down /sbin/ip link set $IFACE down
 up /sbin/ifconfig $IFACE txqueuelen 10000
 


### PR DESCRIPTION
Following the proposal at
https://github.com/hatlabs/discussions/discussions/17
and
https://www.segeln-forum.de/thread/86708-openmarine-mcarthur-hat/?postID=2508782#post2508782
it seems to make sense to add this restart handling.
Additionally the startup group for the can interface has been moved from "hotplug" to "auto". This should avoid problems with the device already being brought up with invalid parameters from an early start of the canboat service.
